### PR TITLE
Fix md5 checksum recording

### DIFF
--- a/src/interface.rs
+++ b/src/interface.rs
@@ -6,7 +6,8 @@ use proc_qq::*;
 use rand::Rng;
 
 use std::fs::OpenOptions;
-use std::io::{BufRead, BufReader, Read, Write};
+use std::io::{BufRead, BufReader, Write};
+use std::mem;
 use std::path::Path;
 use std::{fs::create_dir, fs::read, fs::read_dir, fs::File};
 
@@ -55,18 +56,19 @@ async fn download_image(url: &str) -> Result<bytes::Bytes> {
 fn compare_md5(source_str: &str, md5_buf: &[u8]) -> Result<bool> {
     let compare = compute_md5sum(md5_buf);
     let mut file = File::open(source_str).or_else(|_| File::create(source_str))?;
-    if file.try_clone()?.bytes().count() == 0 {
+    if file.metadata()?.len() == 0 {
         writeln!(file,"{}",compare)?;
         return Ok(true);
     }
     let mut reader = BufReader::new(file);
     let mut md5_str = "".into();
-    while reader.read_line(&mut md5_str).is_ok() {
-        if md5_str == compare {
+    while reader.read_line(&mut md5_str)? > 0 {
+        if md5_str.trim_end() == compare {
             return Ok(false);
         }
         md5_str.clear();
     }
+    mem::drop(reader);
     //
     let mut file = OpenOptions::new().append(true).open(source_str)?;
     writeln!(file, "{}", compare)?;


### PR DESCRIPTION
Idk if the `mem::drop(reader);` part is necessary though.